### PR TITLE
Add support for fixtures directory per module (vs. per class) using a ^ p

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case.php
@@ -742,7 +742,8 @@ abstract class EcomDev_PHPUnit_Test_Case extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Loads YAML file from directory inside of the unit test class
+     * Loads YAML file from directory inside of the unit test class or
+     * the directory inside the module directory if name is prefixed with ^
      *
      * @param string $className class name for looking fixture files
      * @param string $type type of YAML data (fixtures,expectations,dataproviders)
@@ -759,9 +760,18 @@ abstract class EcomDev_PHPUnit_Test_Case extends PHPUnit_Framework_TestCase
             EcomDev_Utils_Reflection::getRelflection($className)->getFileName()
         );
 
-        $filePath = $classFileObject->getPath() . DS
-                  . $classFileObject->getBasename('.php') . DS
-                  . $type . DS . $name;
+        // When prefixed with ^, load from the module's Test/<type> directory
+        if (strpos($name, '^') === 0) {
+            $name = substr($name, 1);
+            $moduleName = substr($className, 0, strpos($className, '_Test_'));;
+            $filePath = Mage::getModuleDir('', $moduleName) . DS . 'Test' . DS;
+        }
+        // Otherwise load from the Class/<type> directory
+        else {
+            $filePath = $classFileObject->getPath() . DS
+                      . $classFileObject->getBasename('.php') . DS;
+        }
+        $filePath .= $type . DS . $name;
 
         if (file_exists($filePath)) {
             return $filePath;


### PR DESCRIPTION
I found the need for sharing some fixtures between classes so I came up with this solution to allow fixtures to be loaded easily from the module directory instead of the class directory. E.g.:

```
@loadSharedFixture ^base.yaml
```

loads `app/code/local/My/Module/Test/fixtures/base.yaml`

Let me know what you think.
