### PR TITLE
Use file copy instead of symlink for local.xmp.phpunit when deployed with

### DIFF
--- a/modman
+++ b/modman
@@ -1,8 +1,14 @@
 # EcomDev_PHPUnit definition
 UnitTests.php                           UnitTests.php
 app/etc/modules/EcomDev_PHPUnit.xml     app/etc/modules/EcomDev_PHPUnit.xml
-app/etc/local.xml.phpunit               app/etc/local.xml.phpunit
 app/code/community/EcomDev/PHPUnit      app/code/community/EcomDev/PHPUnit
 lib/EcomDev/PHPUnit                     lib/EcomDev/PHPUnit
 lib/EcomDev/Utils                       lib/EcomDev/Utils
 lib/Spyc                                lib/Spyc
+
+# Copy local.xml.phpunit if it doesn't already exist
+@shell \
+LOCALXML=app/etc/local.xml.phpunit; \
+if [ ! -f $PROJECT/$LOCALXML ]; then \
+  cp $MODULE/$LOCALXML $PROJECT/$LOCALXML; \
+fi


### PR DESCRIPTION
Use file copy instead of symlink for local.xmp.phpunit when deployed with modman.
