### PR TITLE
Constraint evaluate fix

### DIFF
--- a/lib/EcomDev/PHPUnit/Constraint/Abstract.php
+++ b/lib/EcomDev/PHPUnit/Constraint/Abstract.php
@@ -149,12 +149,29 @@ abstract class EcomDev_PHPUnit_Constraint_Abstract
 
     /**
      * Evaluates value by type.
-     * (non-PHPdoc)
+     *
      * @see PHPUnit_Framework_Constraint::evaluate()
+     *
+     * @param  mixed $other Value or object to evaluate.
+     * @param  string $description Additional information about the test
+     * @param  bool $returnResult Whether to return a result or throw an exception
+     * @return mixed
      */
-    public function evaluate($other)
+    public function evaluate($other, $description = '', $returnResult = false)
     {
-        return $this->callProtectedByType('evaluate', $other);
+        $success = false;
+
+        if ($this->callProtectedByType('evaluate', $other)) {
+            $success = true;
+        }
+
+        if ($returnResult) {
+            return $success;
+        }
+
+        if (!$success) {
+            $this->fail($other, $description);
+        }
     }
 
     /**


### PR DESCRIPTION
This commit should fix a lot of liar assertions. Let's consider the following test example:

``` php
<?php
class MyCompany_Module_Test_Config_Config extends EcomDev_PHPUnit_Test_Case_Config
{
    /**
     * Assert that this module's front name is 'foo'
     *
     * @return void
     */
    public function testModuleFrontNameIsFoo()
    {
        $this->assertConfigNodeValue('frontend/routers/module/args/frontName', 'foo');
        $this->assertConfigNodeValue('frontend/routers/module/args/frontName', 'bar');
    }
}
```

``` xml
<config>
    <phpunit>
        <suite>
            <modules>
                <MyCompany_Module />
            </modules>
        </suite>
    </phpunit>
    <frontend>
        <routers>
            <module>
                <args>
                    <module>MyCompany_Module</module>
                    <frontName>foo</frontName>
                </args>
            </module>
        </routers>
    </frontend>
</config>

```

Before this commit the test will be passed.
