### PR TITLE
Cookie bugfix

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case/Controller.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case/Controller.php
@@ -1846,7 +1846,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Controller extends EcomDev_PHPUnit_Test
             $path = $cookieStub->getPath();
         }
 
-        if ($domain !== null) {
+        if ($domain === null) {
             $domain = $cookieStub->getDomain();
         }
 


### PR DESCRIPTION
fix if cookie domain is null, should use the stub's getDomain method only if `=== null` rather than `!== null`. thanks guys, love this extension.
