### PR TITLE
removed auto appending '/data' to helper mocking.

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case.php
@@ -341,11 +341,6 @@ abstract class EcomDev_PHPUnit_Test_Case extends PHPUnit_Framework_TestCase
             );
         }
 
-
-        if ($type == 'helper' && strpos($classAlias, '/') === false) {
-            $classAlias .= '/data';
-        }
-
         if (in_array($type, array('model', 'resource_model'))) {
             $this->app()->getConfig()->replaceInstanceCreation($type, $classAlias, $mock);
             $type = str_replace('model', 'singleton', $type);


### PR DESCRIPTION
Hi, when i tried to mock Mage::helper('company_module') with $this->replaceByMock('helper', 'company_module', $helperMock), it appended in '/data' to class alias so it replaced key '_helper/company_module/data' in Mage registry with my test mock. But original Mage::helper('company_module') requests key without '/data' suffix ('_helper/company_module'), so it still returns unwanted original class instead of mock.
So I removed auto appending '/data' to helper class. I think it should be on developer (tester) to use right class alias or other solution is to replace both class aliases ('_helper/company_module/data' and '_helper/company_module') with mock.
