### PR TITLE
Api config test case

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case/Config.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case/Config.php
@@ -63,7 +63,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Config extends EcomDev_PHPUnit_Test_Cas
             new EcomDev_PHPUnit_Constraint_Config_Module($moduleName, $type, $expectedValue)
         );
     }
-    
+
     /**
      * A new constraint for checking resources node
      *
@@ -76,7 +76,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Config extends EcomDev_PHPUnit_Test_Cas
                                           $type = EcomDev_PHPUnit_Constraint_Config_Resource::TYPE_SETUP_DEFINED,
                                           $expectedValue = null)
     {
-        
+
         return self::config(
             new EcomDev_PHPUnit_Constraint_Config_Resource($moduleName, $type,
                                                            self::app()->getConfig()->getModuleDir('', $moduleName),
@@ -103,7 +103,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Config extends EcomDev_PHPUnit_Test_Cas
                                                                   $resourceName, $expectedValue)
         );
     }
-    
+
 
     /**
      * A new constraint for checking class alias nodes
@@ -121,7 +121,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Config extends EcomDev_PHPUnit_Test_Cas
             new EcomDev_PHPUnit_Constraint_Config_ClassAlias($group, $classAlias, $expectedClassName, $type)
         );
     }
-    
+
     /**
      * A new constraint for checking table alias nodes
      *
@@ -205,13 +205,13 @@ abstract class EcomDev_PHPUnit_Test_Case_Config extends EcomDev_PHPUnit_Test_Cas
             $moduleName = self::getModuleNameFromCallStack();
         }
         self::assertThatConfig(
-            self::configResource($moduleName, 
-                                 EcomDev_PHPUnit_Constraint_Config_Resource::TYPE_SETUP_DEFINED, 
+            self::configResource($moduleName,
+                                 EcomDev_PHPUnit_Constraint_Config_Resource::TYPE_SETUP_DEFINED,
                                  $expectedResourceName),
             $message
         );
     }
-    
+
     /**
      * Asserts that config resource for module is NOT defined
      *
@@ -227,8 +227,8 @@ abstract class EcomDev_PHPUnit_Test_Case_Config extends EcomDev_PHPUnit_Test_Cas
         }
         self::assertThatConfig(
             self::logicalNot(
-                self::configResource($moduleName, 
-                                     EcomDev_PHPUnit_Constraint_Config_Resource::TYPE_SETUP_DEFINED, 
+                self::configResource($moduleName,
+                                     EcomDev_PHPUnit_Constraint_Config_Resource::TYPE_SETUP_DEFINED,
                                      $expectedResourceName)
             ),
             $message
@@ -419,7 +419,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Config extends EcomDev_PHPUnit_Test_Cas
     {
         self::assertSchemeSetupNotExists($moduleName, $expectedResourceName, $message);
     }
-    
+
     /**
      * Asserts that config node value is equal to the expected value.
      *
@@ -432,7 +432,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Config extends EcomDev_PHPUnit_Test_Cas
     public static function assertConfigNodeValue($nodePath, $expectedValue, $message = '',
         $type = EcomDev_PHPUnit_Constraint_Config_Node::TYPE_EQUALS_STRING)
     {
-        self::assertThatConfig(
+        static::assertThatConfig(
             self::configNode($nodePath, $type, $expectedValue),
             $message
         );
@@ -1068,7 +1068,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Config extends EcomDev_PHPUnit_Test_Cas
             $message
         );
     }
-    
+
     /**
      * Assert that table alias is mapped to expected table name
      *

--- a/app/code/community/EcomDev/PHPUnit/Test/Case/Config/Api.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case/Config/Api.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHP Unit test suite for Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category   EcomDev
+ * @package    EcomDev_PHPUnit
+ * @copyright  Copyright (c) 2012 Oggetto Web ltd. (http://www.oggettoweb.com/)
+ * @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+/**
+ * api.xml config test case
+ *
+ * @category   EcomDev
+ * @package    EcomDev_PHPUnit
+ * @author     Valentin Sushkov <vsushkov@oggettoweb.com>
+ */
+class EcomDev_PHPUnit_Test_Case_Config_Api extends EcomDev_PHPUnit_Test_Case_Config
+{
+    /**
+     * Executes configuration constraint
+     *
+     * @param EcomDev_PHPUnit_Constraint_Config $constraint
+     * @param string $message
+     */
+    public static function assertThatConfig(EcomDev_PHPUnit_Constraint_Config $constraint, $message)
+    {
+        self::assertThat(Mage::getSingleton('api/config'), $constraint, $message);
+    }
+}


### PR DESCRIPTION
Sometimes you need to create additional Magento API methods. To achieve
this the api.xml files are used. Config values from api.xml files are
not loaded in the same time with values from config.xml.

To test api.xml your test case should extend
EcomDev_PHPUnit_Test_Case_Config_Api class. All config paths are
supposed to be inside config/api node.
