### PR TITLE
Fix strict notice

### DIFF
--- a/lib/EcomDev/PHPUnit/Constraint/Config.php
+++ b/lib/EcomDev/PHPUnit/Constraint/Config.php
@@ -58,7 +58,7 @@ class EcomDev_PHPUnit_Constraint_Config extends PHPUnit_Framework_Constraint
      * @param string  $description
      * @param boolean $not
      */
-    public function fail($other, $description, $not)
+    public function fail($other, $description, PHPUnit_Framework_ComparisonFailure $not = null)
     {
         $nodeValue = $this->getNodeValue($other);
 


### PR DESCRIPTION
Fix strict notice: Declaration of EcomDev_PHPUnit_Constraint_Config::fail()
should be compatible with PHPUnit_Framework_Constraint::fail()
