### PR TITLE
Fixed fatal error if "false" as block was given.

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Layout.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Layout.php
@@ -321,7 +321,7 @@ class EcomDev_PHPUnit_Model_Layout
     {
         $this->_collectedBlock = null;
         parent::_generateBlock($node, $parent);
-        if (!empty($this->_collectedBlock)) {
+        if ($this->_collectedBlock) {
             $target = $this->_collectedBlock->getNameInLayout();
             $params = array();
             if (isset($node['as'])) {


### PR DESCRIPTION
parent::_generateBlock can return "false" instead of "null". This causes a fatal error.
