### PR TITLE
The use of require_once instead require in UnitTests.php

### DIFF
--- a/UnitTests.php
+++ b/UnitTests.php
@@ -1,6 +1,6 @@
 <?php
 
-require 'app/Mage.php';
+require_once 'app/Mage.php';
 
 if (version_compare(PHP_VERSION, '5.3', '<')) {
     exit('Magento Unit Tests can be runned only on PHP version over 5.3');


### PR DESCRIPTION
I would like to bootstrap `app/Mage.php` for Selenium test cases in phpunit.xml.
I suggest to use `require_once` instead `require` to avoid loading conflicts. 
