### PR TITLE
Fixed bug that prevented getting all attribute information from fixture

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Fixture.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Fixture.php
@@ -973,7 +973,7 @@ class EcomDev_PHPUnit_Model_Fixture
 
 		$this->getResource()->commit();
 
-		$this->setStorageData(self::STORAGE_KEY_ATTRIBUTES, array_keys($attributes));
+		$this->setStorageData(self::STORAGE_KEY_ATTRIBUTES, $attributes);
 
 		return $this;
 	}


### PR DESCRIPTION
Fixed bug in attribute loader — allows getting all information about fixture attributes from fixture storage.
