### PR TITLE
app/code/design does not exist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,7 +30,7 @@
             <!-- Exclude Mage.php file from code coverage -->
             <file>app/Mage.php</file>
             <!-- Exclude template files -->
-            <directory suffix=".phtml">app/code/design</directory>
+            <directory suffix=".phtml">app/design</directory>
             <!-- Exclude Varien & Zend libraries -->
             <directory suffix=".php">lib/Varien</directory>
             <directory suffix=".php">lib/Zend</directory>


### PR DESCRIPTION
Did the following...

cd ~/
modman clone git://github.com/IvanChepurnyi/EcomDev_PHPUnit.git
git checkout dev

cd /var/www/html/
modman link ~/EcomDev_PHPUnit/
 Applied: UnitTests.php                   UnitTests.php
 Applied: app/etc/modules/EcomDev_PHPUnit.xml  app/etc/modules/EcomDev_PHPUnit.xml
 Applied: app/code/community/EcomDev/PHPUnit  app/code/community/EcomDev/PHPUnit
 Applied: lib/EcomDev/PHPUnit             lib/EcomDev/PHPUnit
 Applied: lib/EcomDev/Utils               lib/EcomDev/Utils
 Applied: lib/Spyc                        lib/Spyc
Successfully create symlink new module 'EcomDev_PHPUnit'

phpunit
app/code/design does not exist
