### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "description": "Magento PHPUnit Integration",
     "homepage": "http://www.ecomdev.org/shop/code-testing/php-unit-test-suite.html",
     "require": {
-        "magento-hackathon/magento-composer-installer": "dev-master",
-        "phpunit/phpunit": "3.6.*"
+        "magento-hackathon/magento-composer-installer": "*",
+        "phpunit/phpunit": "3.7.*"
     },
     "authors":[
         {


### PR DESCRIPTION
According to the README.md the extension requires PHPUnit 3.7.*, so
let's show it in the composer.json file. Also update
magento-composer-installer required version in order to make this
extension compatiable with other Magento extension installed via
composer.
