### PR TITLE
Update composer.json for v0.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "description": "Magento PHPUnit Integration",
     "homepage": "http://www.ecomdev.org/shop/code-testing/php-unit-test-suite.html",
     "require": {
-        "magento-hackathon/magento-composer-installer": "dev-master",
-        "phpunit/phpunit": "3.6.*"
+        "magento-hackathon/magento-composer-installer": "*",
+        "phpunit/phpunit": "3.7.*"
     },
     "authors":[
         {


### PR DESCRIPTION
I see from the README you've bumped `phpunit` up to 3.7.x.
I have updated `composer.json` to reflect this.

Also changed `"magento-hackathon/magento-composer-installer":` dependancy to `"*"`

I think this is the preferred version to pin for `magento-composer-installer` //cc @vinai
