### PR TITLE
fix TestCase::setUp for error 'host is not set for base url' testing Model and Helper Classes

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case.php
@@ -718,4 +718,17 @@ abstract class EcomDev_PHPUnit_Test_Case extends PHPUnit_Framework_TestCase
     {
         return TestUtil::call($method, $args);
     }
+
+    /**
+     * Set up controller params
+     * (non-PHPdoc)
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $_SESSION = array();
+        $_baseUrl = Mage::getStoreConfig('web/unsecure/base_url');
+        $this->app()->getRequest()->setBaseUrl($_baseUrl);
+    }
 }


### PR DESCRIPTION
## Helper and Model Test Cases inherits from EcomDev_PHPUnit_Test_Case, but this class don't have setUp method for setting base_url. When some test uses a method that require the singleton 'customer/session' the base_url is used to initialize session... I wrote a minimal setUp method for base EcomDev_PHPUnit_Test_Case that initialize a request and set base_url

fix EcomDev_PHPUnit_Test_Case::setUp for error 'Cannot run controller test, because the host is not set for base url.' for tests based on EcomDev_PHPUnit_Test_Case that uses singleton customer/session. ex: helper test for Product::getFinalPrice
