### PR TITLE
Call Db_Adapter_Interface::startSetup() & endSetup() for table fixtures

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture.php
@@ -66,13 +66,14 @@ class EcomDev_PHPUnit_Model_Mysql4_Fixture extends Mage_Core_Model_Mysql4_Abstra
         }
 
         try {
+            /** @var $setup Mage_Core_Model_Resource_Setup */
+            $setup = Mage::getResourceModel('core/setup', 'eav_write')->startSetup();
             $this->_getWriteAdapter()
-                    ->startSetup()
                     ->insertOnDuplicate(
                         $this->getTable($tableEntity),
                         $records
                     );
-            $this->_getWriteAdapter()->endSetup();
+            $setup->endSetup();
         } catch (Exception $e) {
         	throw new EcomDev_PHPUnit_Model_Mysql4_Fixture_Exception(
     			sprintf('Unable to insert/update records for a table "%s"', $tableEntity), 

--- a/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture.php
@@ -66,10 +66,13 @@ class EcomDev_PHPUnit_Model_Mysql4_Fixture extends Mage_Core_Model_Mysql4_Abstra
         }
 
         try {
-	        $this->_getWriteAdapter()->insertOnDuplicate(
-	            $this->getTable($tableEntity),
-	            $records
-	        );
+            $this->_getWriteAdapter()
+                    ->startSetup()
+                    ->insertOnDuplicate(
+                        $this->getTable($tableEntity),
+                        $records
+                    );
+            $this->_getWriteAdapter()->endSetup();
         } catch (Exception $e) {
         	throw new EcomDev_PHPUnit_Model_Mysql4_Fixture_Exception(
     			sprintf('Unable to insert/update records for a table "%s"', $tableEntity), 

--- a/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture.php
@@ -67,7 +67,7 @@ class EcomDev_PHPUnit_Model_Mysql4_Fixture extends Mage_Core_Model_Mysql4_Abstra
 
         try {
             /** @var $setup Mage_Core_Model_Resource_Setup */
-            $setup = Mage::getResourceModel('core/setup', 'eav_write')->startSetup();
+            $setup = Mage::getResourceModel('core/setup', 'default_write')->startSetup();
             $this->_getWriteAdapter()
                     ->insertOnDuplicate(
                         $this->getTable($tableEntity),


### PR DESCRIPTION
Given a table fixtures like this:

tables:
  customer/customer_group:
    - customer_group_id: 0
      customer_group_code: NOT LOGGED IN
      tax_class_id: 3
    - customer_group_id: 1
      customer_group_code: General
      tax_class_id: 3

The primary key 0 will be affected by the mysql auto increment setting,
So in this example the customer_group_id for the group NOT LOGGED IN
would be the next auto_increment value for that column table.
Calling Varien_Db_Adapter_Pdo_Mysql::startSetup() calls
"SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO'" which
fixes this behaviour.