### PR TITLE
Fix typo in class name

### DIFF
--- a/lib/EcomDev/PHPUnit/Helper/Abstract.php
+++ b/lib/EcomDev/PHPUnit/Helper/Abstract.php
@@ -19,7 +19,7 @@
 /**
  * Base helper implementation
  */
-abstract class EcomDev_PHPUnit_Helper_Abstract implements EcomDev_PHPunit_Helper_Interface
+abstract class EcomDev_PHPUnit_Helper_Abstract implements EcomDev_PHPUnit_Helper_Interface
 {
     /**
      * @var PHPUnit_Framework_TestCase


### PR DESCRIPTION
Fix typo in class name. This typo may cause an error on case-sensitive systems.
