### PR TITLE
Forward Infos are not cleared

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Controller/Request/Http.php
+++ b/app/code/community/EcomDev/PHPUnit/Controller/Request/Http.php
@@ -147,6 +147,9 @@ class EcomDev_PHPUnit_Controller_Request_Http
      */
     public function resetInternalProperties()
     {
+        // old forward infos
+        $this->_beforeForwardInfo = null;
+        
         // From abstract request
         $this->_dispatched = false;
         $this->_module = null;


### PR DESCRIPTION
Ensure that forward infos from tests are cleared while resetting the request.
Otherwise it is not possible to use assertRequestNotForwarded() if a previous controller test has already triggered a forwarding
