### PR TITLE
Fix for autoloader problems with Varien_Autoload and PHPUnit extension

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/bootstrap.php
+++ b/app/code/community/EcomDev/PHPUnit/bootstrap.php
@@ -22,3 +22,14 @@ $_SERVER['SCRIPT_FILENAME'] = $_baseDir . DS . 'index.php';
 
 Mage::app('admin');
 Mage::getConfig()->init();
+
+spl_autoload_unregister(array(\Varien_Autoload::instance(), 'autoload'));
+
+spl_autoload_register(function ($classname) {
+    $classname = ltrim($classname, "\\");
+    preg_match('/^(.+)?([^\\\\]+)$/U', $classname, $match);
+    $classname = str_replace("\\", "/", $match[1])
+        . str_replace(array("\\", "_"), "/", $match[2])
+        . ".php";
+    @include_once $classname;
+});


### PR DESCRIPTION
Posible fix for warnings throwed by Varien_Autoload which are triggered by PHPUnit (class_exist) calls.
