### PR TITLE
AdminGws Problems in EE 1.13

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case/Controller.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case/Controller.php
@@ -2027,7 +2027,22 @@ abstract class EcomDev_PHPUnit_Test_Case_Controller extends EcomDev_PHPUnit_Test
             array('login', 'getId', 'save', 'authenticate', 'getRole')
         );
 
-        $adminRoleMock = $this->getModelMock('admin/roles', array('getGwsIsAll'));
+        $adminRoleMock = $this->getModelMock(
+            'admin/roles',
+            array('getGwsIsAll', 'getGwsStores', 'getGwsStoreGroups', 'getGwsRelevantWebsites')
+        );
+
+        $adminRoleMock->expects($this->any())
+            ->method('getGwsStores')
+            ->will($this->returnValue(array_keys(Mage::app()->getStores(true))));
+
+        $adminRoleMock->expects($this->any())
+            ->method('getGwsStoreGroups')
+            ->will($this->returnValue(array_keys(Mage::app()->getGroups(true))));
+
+        $adminRoleMock->expects($this->any())
+            ->method('getGwsRelevantWebsites')
+            ->will($this->returnValue(array_keys(Mage::app()->getWebsites(true))));
 
         $adminRoleMock->expects($this->any())
             ->method('getGwsIsAll')


### PR DESCRIPTION
I currently trying to run a controller test in EE 1.13 and i got errors.
It seems that there are three new checks in AdminGws module.
I'm really unsure if this is a correct solution, but i additionally mocked the methods getGwsStores, getGwsStoreGroups and getGwsRelevantWebsites.

Please have a look at my code.
