### PR TITLE
vfsStream now can even be used if autoload was configured from extern

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Fixture.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Fixture.php
@@ -739,6 +739,9 @@ class EcomDev_PHPUnit_Model_Fixture
 
         if (is_dir(Mage::getBaseDir('lib')  . DS . 'vfsStream' . DS . 'src')) {
             spl_autoload_register(array($this, 'vfsAutoload'), true, true);
+        }
+
+        if( class_exists('\org\bovigo\vfs\vfsStream') ){
             $this->_vfs = Mage::getModel('ecomdev_phpunit/fixture_vfs');
             return $this->_vfs;
         }


### PR DESCRIPTION
i have a special environment where i make heavy use of composer, so I dont use the submodule approach. So the vfsStream is already in autoload registered when this part is called.

former pull request https://github.com/EcomDev/EcomDev_PHPUnit/pull/105
