### PR TITLE
Prevent Warning

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Config.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Config.php
@@ -125,6 +125,7 @@ class EcomDev_PHPUnit_Model_Config extends Mage_Core_Model_Config
      */
     public function getModelInstance($modelClass='', $constructArguments=array())
     {
+    	$modelClass = trim($modelClass);
         if (!isset($this->_replaceInstanceCreation['model'][$modelClass])) {
             return parent::getModelInstance($modelClass, $constructArguments);
         }


### PR DESCRIPTION
$modelClass can be an instance of Mage_Core_Model_Config_Element.
In this case a warning comes up on the isset statement.
