### PR TITLE
Able to start sessions as guest for special methods

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case.php
@@ -29,6 +29,7 @@ use EcomDev_PHPUnit_Helper as TestHelper;
  * @method EcomDev_PHPUnit_Mock_Proxy mockSession($classAlias, array $methods = array())
  * @method EcomDev_PHPUnit_Mock_Proxy adminSession(array $resources = array())
  * @method EcomDev_PHPUnit_Mock_Proxy customerSession(int $customerId)
+ * @method EcomDev_PHPUnit_Mock_Proxy guestSession()
  */
 abstract class EcomDev_PHPUnit_Test_Case extends PHPUnit_Framework_TestCase
 {

--- a/app/code/community/EcomDev/PHPUnit/Test/Case/Helper/Guest.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case/Helper/Guest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * PHP Unit test suite for Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   EcomDev
+ * @package    EcomDev_PHPUnit
+ * @copyright  Copyright (c) 2013 EcomDev BV (http://www.ecomdev.org)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @author     Mike Pretzlaw <pretzlaw@gmail.com>
+ */
+
+use EcomDev_PHPUnit_Helper as TestHelper;
+use EcomDev_PHPUnit_Test_Case_Util as TestUtil;
+
+/**
+ * Helper for stubbing customer session
+ *
+ *
+ */
+class EcomDev_PHPUnit_Test_Case_Helper_Guest extends EcomDev_PHPUnit_Helper_Abstract
+{
+    /**
+     * Start session as guest.
+     *
+     * @param string|int|null $storeId
+     *
+     * @return EcomDev_PHPUnit_Mock_Proxy
+     */
+    public function helperGuestSession($storeId = null)
+    {
+        $guestSessionMock = TestHelper::invoke(
+            'mockSession',
+            'core/session',
+            array('renewSession')
+        );
+
+        /** @var Mage_Core_Model_Session $session */
+        $session                                  = $guestSessionMock->getMock();
+        $_GET[$session->getSessionIdQueryParam()] = $session->getSessionId(); // some action need that (loginPost, ...)
+
+        if ($storeId === null)
+        {
+            $storeId = TestUtil::app()->getAnyStoreView()->getCode();
+        }
+
+        TestUtil::setCurrentStore($storeId);
+
+        return $guestSessionMock;
+    }
+}

--- a/app/code/community/EcomDev/PHPUnit/etc/config.xml
+++ b/app/code/community/EcomDev/PHPUnit/etc/config.xml
@@ -99,11 +99,11 @@
                     <tables>ecomdev_phpunit/fixture_processor_tables</tables>
                     <vfs>ecomdev_phpunit/fixture_processor_vfs</vfs>
                 </processors>
-	            <attribute>
-		            <!-- Fixture loaders for EAV attributes
-		                 Default can be used but does not support extra attribute table configuration -->
-		            <default>ecomdev_phpunit/fixture_attribute_default</default>
-	            </attribute>
+                <attribute>
+                    <!-- Fixture loaders for EAV attributes
+                         Default can be used but does not support extra attribute table configuration -->
+                    <default>ecomdev_phpunit/fixture_attribute_default</default>
+                </attribute>
                 <eav>
                     <!-- Here goes the list of fixture loaders for EAV entities
                          If no fixture loader is specified for entity, then default will be used
@@ -146,6 +146,7 @@
                 <mock>EcomDev_PHPUnit_Test_Case_Helper_Mock</mock>
                 <session>EcomDev_PHPUnit_Test_Case_Helper_Session</session>
                 <customer>EcomDev_PHPUnit_Test_Case_Helper_Customer</customer>
+                <guest>EcomDev_PHPUnit_Test_Case_Helper_Guest</guest>
             </helpers>
         </suite>
     </phpunit>


### PR DESCRIPTION
Some methods need a session to dispatch correct. (eg customer/account/loginPost)
Instead of fixing the dispatch method I wrote a guest session.
This sets the needed $_GET[session_name] = session_id to have a successfull call for such "loginPost" actions.

This:

```
        $this->dispatch('customer/account/loginPost');

        $this->assertRequestRoute('customer/account/loginPost');
```

Will fail with:

```
Failed asserting that request route matches expected one.
--- Expected
+++ Actual
@@ @@
-'core/index/noCookies'
+'customer/account/loginPost'
```

And this is the fix:

```
        $this->guestSession();
        $this->dispatch('customer/account/loginPost');

        $this->assertRequestRoute('customer/account/loginPost');
```

Excuse the indention in config.xml this was the auto code format during the commit.
