### PR TITLE
Dev get block

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case.php
@@ -297,6 +297,24 @@ abstract class EcomDev_PHPUnit_Test_Case extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Retrieves a block by its alias.
+     *
+     *
+     * @param string $blockAlias
+     * @return Mage_Core_Block_Template|bool
+     */
+    public function getBlock($blockAlias)
+    {
+        $tmpName = uniqid('m') . '_' . uniqid('p');
+        $this->app()->getLayout()->createBlock($blockAlias, $tmpName);
+        $getBlock = $this->app()->getLayout()->getBlock($tmpName);
+        $this->app()->getLayout()->removeOutputBlock($tmpName);
+
+        return $getBlock;
+    }
+
+
+    /**
      * Retrieves annotation by its name from different sources (class, method) based on meta information
      *
      * @param string $className


### PR DESCRIPTION
Get instance of a block by magento standard and without harming the layout.

`Mage::getBlockSingleton` does only work if the block has been loaded in the layout.
This new method `getBlock` loads a block in the layout, fetches the reference and removes it from the layout.