### PR TITLE
Set base Url whenever needed

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case.php
@@ -325,6 +325,23 @@ abstract class EcomDev_PHPUnit_Test_Case extends PHPUnit_Framework_TestCase
         return $this->expected($arguments);
     }
 
+
+    /**
+     * Set a base url when needed in tests.
+     *
+     * This will set a base URL which is needed if you want to test some "getUrl" in a
+     * helper or block.
+     *
+     * @param string $baseUrl
+     *
+     * @return void
+     */
+    public function mockBaseUrl($baseUrl = 'http://127.0.0.1/')
+    {
+        $this->app()->getRequest()->reset();
+        $this->app()->getRequest()->setBaseUrl($baseUrl);
+    }
+
     /**
      * Replaces Magento resource by mock object
      *

--- a/app/code/community/EcomDev/PHPUnit/Test/Case/Controller.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case/Controller.php
@@ -1905,8 +1905,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Controller extends EcomDev_PHPUnit_Test
         $urlModel = $this->getUrlModel(null, $initialUrlParams);
         $baseUrl = $urlModel->getBaseUrl($initialUrlParams);
 
-        $this->getRequest()->reset();
-        $this->getRequest()->setBaseUrl($baseUrl);
+        $this->mockBaseUrl($baseUrl);
 
         $this->getResponse()->reset();
         $this->getLayout()->reset();


### PR DESCRIPTION
Base URL is not only needed for controller tests.
Helper, Blocks etc will also need this especially when they use `getUrl()`.

Please merge and add additional lines so that the URL set in argument $baseUrl will realy reach it's destination.
Till now it always falls back to the configured baseUrl, which won't be what to expect from this method.
