### PR TITLE
Registry throws error on already set keys

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/App.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/App.php
@@ -340,6 +340,17 @@ class EcomDev_PHPUnit_Model_App extends Mage_Core_Model_App
     }
 
     /**
+     * Reset registry
+     *
+     * @return $this
+     */
+    public function resetRegistry()
+    {
+        EcomDev_Utils_Reflection::setRestrictedPropertyValue('Mage', '_registry', array());
+        return $this;
+    }
+
+    /**
      * Removes event area
      *
      * @param string $code area code

--- a/app/code/community/EcomDev/PHPUnit/Test/Case/Controller.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case/Controller.php
@@ -1953,6 +1953,7 @@ abstract class EcomDev_PHPUnit_Test_Case_Controller extends EcomDev_PHPUnit_Test
         $urlModel = $this->getUrlModel($route, $params);
 
         $this->app()->resetAreas();
+        $this->app()->resetRegistry();
 
         $requestUri = $urlModel->getUrl($route, $params);
         $baseUrl = $urlModel->getBaseUrl($params);


### PR DESCRIPTION
Between tests the registry seems to persist, so clean it before every dispatch.

Maybe you like to clean it before every test. But I don't know if that makes sense.
