### PR TITLE
Modman file support for dist and local.xml files

### DIFF
--- a/modman
+++ b/modman
@@ -5,6 +5,8 @@ lib/EcomDev/*                           lib/EcomDev/
 lib/Spyc                                lib/Spyc
 lib/vfsStream                           lib/vfsStream
 shell/*.php                             shell/
+phpunit.xml.dist                        phpunit.xml.dist
+app/etc/local.xml.phpunit               app/etc/local.xml.phpunit
 
 # Run shell installer
 @shell  cd $PROJECT/shell && php -f ecomdev-phpunit.php -- --action install


### PR DESCRIPTION
Missing files in the modman install cause the installation to be broken and requires manual creation of the files.
