### PR TITLE
Issue #166 Add default website/store scope to fixture.

### DIFF
--- a/app/code/community/EcomDev/PHPUnitTest/Test/Helper/_data/fx-customers.yaml
+++ b/app/code/community/EcomDev/PHPUnitTest/Test/Helper/_data/fx-customers.yaml
@@ -1,3 +1,23 @@
+scope:
+  website: # Initialize websites
+    - website_id: 1
+      code: base
+      name: Default Website
+      default_group_id: 1
+  group: # Initializes store groups
+    - group_id: 1
+      website_id: 1
+      name: Default Store Group
+      default_store_id: 1
+      root_category_id: 2 # Default Category
+  store: # Initializes store views
+    - store_id: 1
+      website_id: 1
+      group_id: 1
+      code: default
+      name: Default Store
+      is_active: 1
+
 eav:
   customer:
     - entity_id: 1 # Customer with default billing and shipping addresses


### PR DESCRIPTION
Please Note: @fooman 's patch (https://github.com/EcomDev/EcomDev_PHPUnit/pull/82) would likely be required if the database already contains the default website/store.
