### PR TITLE
Clear params on dispatch

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Controller/Request/Http.php
+++ b/app/code/community/EcomDev/PHPUnit/Controller/Request/Http.php
@@ -158,7 +158,7 @@ class EcomDev_PHPUnit_Controller_Request_Http
         // From Http request
         $this->_paramSources = array('_GET', '_POST');
         $this->_requestUri = null;
-        $this->_params = null;
+        $this->_params = array();
         $this->_baseUrl = null;
         $this->_basePath = null;
         $this->_pathInfo = '';


### PR DESCRIPTION
The parameters are not cleared on dispatch meaning a second dispatch carries over parameters from the previous.
