### PR TITLE
Fix strict notice

### DIFF
--- a/lib/EcomDev/PHPUnit/Constraint/Layout/Block/Property.php
+++ b/lib/EcomDev/PHPUnit/Constraint/Layout/Block/Property.php
@@ -81,7 +81,7 @@ class EcomDev_PHPUnit_Constraint_Layout_Block_Property
      * (non-PHPdoc)
      * @see EcomDev_PHPUnit_ConstraintAbstract::getActualValue()
      */
-    protected function getActualValue($other)
+    protected function getActualValue($other = null)
     {
         if ($this->_useActualValue) {
             if ($this->_actualValue instanceof Varien_Object) {


### PR DESCRIPTION
Exception : Strict Notice: Declaration of EcomDev_PHPUnit_Constraint_Layout_Block_Property::getActualValue() should be compatible with EcomDev_PHPUnit_Constraint_Layout_Abstract::getActualValue($other = NULL)  in lib/EcomDev/PHPUnit/Constraint/Layout/Block/Property.php on line 80
