### PR TITLE
fix exception

### DIFF
--- a/lib/EcomDev/PHPUnit/Constraint/Json.php
+++ b/lib/EcomDev/PHPUnit/Constraint/Json.php
@@ -157,7 +157,7 @@ class EcomDev_PHPUnit_Constraint_Json extends EcomDev_PHPUnit_Constraint_Abstrac
      * (non-PHPdoc)
      * @see PHPUnit_Framework_Constraint::customFailureDescription()
      */
-    protected function customFailureDescription($other, $description, $not)
+    protected function customFailureDescription($other)
     {
         return sprintf(
             'string value %s.',


### PR DESCRIPTION
fix exception thrown in EcomDev_PHPUnit_Constraint_Json:

```
Exception: Warning: Missing argument 2 for EcomDev_PHPUnit_Constraint_Json::customFailureDescription(), called in /var/www/html/magento/lib/EcomDev/PHPUnit/Constraint/Abstract.php on line 220 and defined  in /var/www/html/magento/lib/EcomDev/PHPUnit/Constraint/Json.php on line 160

/var/www/html/magento/app/code/core/Mage/Core/functions.php:245
/var/www/html/magento/lib/EcomDev/PHPUnit/Constraint/Json.php:160
/var/www/html/magento/lib/EcomDev/PHPUnit/Constraint/Abstract.php:220
/var/www/html/magento/lib/EcomDev/PHPUnit/Constraint/Abstract.php:194
/var/www/html/magento/lib/EcomDev/PHPUnit/Constraint/Abstract.php:182
/var/www/html/magento/app/code/community/EcomDev/PHPUnit/Test/Case.php:199
/var/www/html/magento/app/code/local/Company/Module/Test/Model/Service/Transport/Import.php:17
/usr/bin/phpunit:46
```
