### PR TITLE
Fix package name displayed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Installation
       ```json
       {
             "require": {
-               "ecomdev/ecomdev_phpunit": "*"
+               "ivanchepurnyi/ecomdev_phpunit": "*"
             }
       }
       ```


### PR DESCRIPTION
The package seems to be named `ivanchepurnyi/ecomdev_phpunit` instead of `ecomdev/ecomdev_phpunit`.  This PR updates the README.md installation example accordingly.

Fixes issue #190. 
