### PR TITLE
fixes #204 getModelInstance() object to string

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Config.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Config.php
@@ -128,7 +128,7 @@ class EcomDev_PHPUnit_Model_Config extends Mage_Core_Model_Config
             return parent::getModelInstance((string)$modelClass, $constructArguments);
         }
 
-        return $this->_replaceInstanceCreation['model'][$modelClass];
+        return $this->_replaceInstanceCreation['model'][(string)$modelClass];
     }
 
     /**


### PR DESCRIPTION
See issue #204 for description of the issue, basically in enterprise a model was getting passed in some cases instead of a string.

Recreated pull request as per instructions in readme, forked from dev and merge to dev, see closed pull request 205 for more info.
