### PR TITLE
Reverse order of fixtures for discard()

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Fixture.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Fixture.php
@@ -481,7 +481,7 @@ class EcomDev_PHPUnit_Model_Fixture
         $this->setStorageData(self::STORAGE_KEY_FIXTURE, null);
 
         $processors = $this->getProcessors();
-        foreach ($this->_fixture as $part => $data) {
+        foreach (array_reverse($this->_fixture, true) as $part => $data) {
             if (isset($processors[$part])) {
                 $processors[$part]->discard($data, $part, $this);
             }


### PR DESCRIPTION
When undoing database changes made by a fixture, run them in reverse order. This prevents conflicts between dependencies with referential integrity constraints where they exist.
