### PR TITLE
Really truly clear config cache on discard fixtures

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Fixture/Processor/Config.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Fixture/Processor/Config.php
@@ -139,6 +139,19 @@ class EcomDev_PHPUnit_Model_Fixture_Processor_Config
     {
         Mage::getConfig()->loadScopeSnapshot();
         Mage::getConfig()->loadDb();
+        
+        // Flush website and store configuration caches
+        foreach (Mage::app()->getWebsites(true) as $website) {
+            EcomDev_Utils_Reflection::setRestrictedPropertyValue(
+            $website, '_configCache', array()
+            );
+        }
+        foreach (Mage::app()->getStores(true) as $store) {
+            EcomDev_Utils_Reflection::setRestrictedPropertyValue(
+            $store, '_configCache', array()
+            );
+        }
+        
         return $this;
     }
 


### PR DESCRIPTION
We found that config fixtures are still retained in memory between tests. This fixes that.
