### PR TITLE
Allow getTable to be called with an array in Magento < 1.6

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture/Eav/Catalog/Abstract.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture/Eav/Catalog/Abstract.php
@@ -28,6 +28,22 @@ abstract class EcomDev_PHPUnit_Model_Mysql4_Fixture_Eav_Catalog_Abstract
     const SCOPE_TYPE_WEBSITE = 'websites';
 
     /**
+     * Overridden to support array arguments (entity name and suffix) in Magento <1.6
+     *
+     * @param string|array $entityName
+     *
+     * @return string
+     */
+    public function getTable($entityName) {
+        if (is_array($entityName) && version_compare(Mage::getVersion(), "1.6", "<")) {
+            list($entityName, $entitySuffix) = $entityName;
+            return parent::getTable($entityName) . "_$entitySuffix";
+        } else {
+            return parent::getTable($entityName);
+        }
+    }
+
+    /**
      * Overridden to add GWS implementation for attribute records
      *
      * @param array $row


### PR DESCRIPTION
This fixes the catalog_category fixture, which calls getTable with the entity name and table suffix, which is not supported in Magento 1.5.
