### PR TITLE
Allow constructor arguments to be passed to a replaceByMock Mock

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Config.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Config.php
@@ -128,7 +128,11 @@ class EcomDev_PHPUnit_Model_Config extends Mage_Core_Model_Config
             return parent::getModelInstance((string)$modelClass, $constructArguments);
         }
 
-        return $this->_replaceInstanceCreation['model'][(string)$modelClass];
+        $instance = $this->_replaceInstanceCreation['model'][(string)$modelClass];
+        if (count($constructArguments) && method_exists($instance, '__construct')) {
+            call_user_func(array($instance, '__construct'), $constructArguments);
+        }
+        return $instance;
     }
 
     /**

--- a/app/code/community/EcomDev/PHPUnitTest/Test/Helper/Mock.php
+++ b/app/code/community/EcomDev/PHPUnitTest/Test/Helper/Mock.php
@@ -70,5 +70,13 @@ class EcomDev_PHPUnitTest_Test_Helper_Mock extends EcomDev_PHPUnit_Test_Case
         $this->assertAttributeContains('some_value', 'constructorArgs', $mock);
     }
 
-
+    public function testReplaceByMockConstructor()
+    {
+        $firstQuote = Mage::getModel('sales/quote');
+        $mock = $this->getModelMock('sales/service_quote', array('_validate'), false, array($firstQuote));
+        $this->replaceByMock('model', 'sales/service_quote', $mock);
+        $secondQuote = Mage::getModel('sales/quote');
+        $service = Mage::getModel('sales/service_quote', $secondQuote);
+        $this->assertEquals(spl_object_hash($secondQuote), spl_object_hash($service->getQuote()));
+    }
 }


### PR DESCRIPTION
When we create mock and swap it out using replaceByMock, the constructor was only called when creating the mock. With this PR, the constructor would be called when using the Mage factory to create a new instance if constructor arguments are passed to the Mage factory. 