### PR TITLE
Bootstrap autoloader patch

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Test/Case/Util.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Case/Util.php
@@ -511,6 +511,7 @@ class EcomDev_PHPUnit_Test_Case_Util
     public static function setUp()
     {
         self::app()->resetDispatchedEvents();
+        self::$originalStore = Mage::app()->getStore()->getCode();
     }
 
     /**

--- a/app/code/community/EcomDev/PHPUnit/Test/Listener.php
+++ b/app/code/community/EcomDev/PHPUnit/Test/Listener.php
@@ -173,6 +173,9 @@ class EcomDev_PHPUnit_Test_Listener implements PHPUnit_Framework_TestListener
         ));
 
         if ($test instanceof PHPUnit_Framework_TestCase) {
+            EcomDev_PHPUnit_Helper::tearDown();
+            EcomDev_PHPUnit_Test_Case_Util::tearDown();
+            
             EcomDev_PHPUnit_Test_Case_Util::getFixture(get_class($test))
                 ->setScope(EcomDev_PHPUnit_Model_FixtureInterface::SCOPE_LOCAL)
                 ->discard(); // Clear applied fixture
@@ -180,9 +183,6 @@ class EcomDev_PHPUnit_Test_Listener implements PHPUnit_Framework_TestListener
             if (EcomDev_PHPUnit_Test_Case_Util::getExpectation(get_class($test))->isLoaded()) {
                 EcomDev_PHPUnit_Test_Case_Util::getExpectation(get_class($test))->discard();
             }
-
-            EcomDev_PHPUnit_Test_Case_Util::tearDown();
-            EcomDev_PHPUnit_Helper::tearDown();
         }
 
         Mage::dispatchEvent('phpunit_test_end_after', array(

--- a/app/code/community/EcomDev/PHPUnit/bootstrap.php
+++ b/app/code/community/EcomDev/PHPUnit/bootstrap.php
@@ -51,6 +51,11 @@ if (!defined('ECOMDEV_PHPUNIT_NO_AUTOLOADER')) {
             )
         );
 
-        @include $filePath . '.php';
+        $classFile = $filePath . '.php';
+        if (stream_resolve_include_path($classFile)) {
+            return include $classFile;
+        } else {
+            return false;
+        }
     });
 }


### PR DESCRIPTION
Autoloader implementations MUST NOT throw exceptions, MUST NOT raise errors of any level.

Fixes errors like this:
PHP Fatal error: Uncaught exception 'Exception' with message 'Warning: include(PHPUnit/Extensions/Story/TestCase.php): failed to open stream: No such file or directory in [..]/vendor/ecomdev/phpunit/app/code/community/EcomDev/PHPUnit/bootstrap.php on line 54' in [...]/htdocs/app/code/core/Mage/Core/functions.php:245