### PR TITLE
Disable Events without Disabling Event Capture

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/App.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/App.php
@@ -225,10 +225,10 @@ class EcomDev_PHPUnit_Model_App extends Mage_Core_Model_App
         $this->replaceRegistry(self::REGISTRY_PATH_SHARED_STORAGE, new Varien_Object());
         return $this;
     }
-    
+
     /**
      * Sets cache options for test case
-     * 
+     *
      * @param array $options
      * @return EcomDev_PHPUnit_Model_App
      */
@@ -243,7 +243,7 @@ class EcomDev_PHPUnit_Model_App extends Mage_Core_Model_App
 
     /**
      * Retrieve cache options for test case
-     * 
+     *
      * @return array
      */
     public function getCacheOptions()
@@ -358,7 +358,7 @@ class EcomDev_PHPUnit_Model_App extends Mage_Core_Model_App
 
     /**
      * Returns request for test suite
-     * 
+     *
      * @see Mage_Core_Model_App::getRequest()
      * @return EcomDev_PHPUnit_Controller_Request_Http
      */
@@ -376,7 +376,7 @@ class EcomDev_PHPUnit_Model_App extends Mage_Core_Model_App
 
     /**
      * Returns response for test suite
-     * 
+     *
      * @see Mage_Core_Model_App::getResponse()
      * @return EcomDev_PHPUnit_Controller_Response_Http
      */
@@ -527,13 +527,13 @@ class EcomDev_PHPUnit_Model_App extends Mage_Core_Model_App
     {
         if ($this->_eventsEnabled) {
             parent::dispatchEvent($eventName, $args);
-
-            if (!isset($this->_dispatchedEvents[$eventName])) {
-                $this->_dispatchedEvents[$eventName] = 0;
-            }
-
-            $this->_dispatchedEvents[$eventName]++;
         }
+
+        if (!isset($this->_dispatchedEvents[$eventName])) {
+            $this->_dispatchedEvents[$eventName] = 0;
+        }
+
+        $this->_dispatchedEvents[$eventName]++;
 
         return $this;
     }


### PR DESCRIPTION
If I do `Mage::app()->disableEvents();` then `assertEventDispatched*` does not detect any events. But if I don't disable events, then I have to manually account for the effects of every observer.

This pull request allows EcomDev to track events that _would have_ been dispatched, without actually dispatching the events. It is compatible with the existing behavior because anyone who was using `disableEvents/enableEvents` before would not have been using `assertEventDispatched` before.

Signed-off-by: Michael A. Smith <msmith3@ebay.com>