### PR TITLE
Check whether SPYC_FROM_COMMAND_LINE is already defined

### DIFF
--- a/lib/Spyc/spyc.php
+++ b/lib/Spyc/spyc.php
@@ -1011,8 +1011,8 @@ class Spyc {
 
 // Enable use of Spyc from command line
 // The syntax is the following: php spyc.php spyc.yaml
-
-define ('SPYC_FROM_COMMAND_LINE', false);
+if (!defined('SPYC_FROM_COMMAND_LINE'))
+  define ('SPYC_FROM_COMMAND_LINE', false);
 
 do {
   if (!SPYC_FROM_COMMAND_LINE) break;


### PR DESCRIPTION
This removes the warning SPYC_FROM_COMMAND_LINE already defined