### PR TITLE
Fix bad assignment of $row

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture/AbstractEav.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture/AbstractEav.php
@@ -245,7 +245,6 @@ abstract class EcomDev_PHPUnit_Model_Mysql4_Fixture_AbstractEav
 
             // Fulfill necessary information
             $values[$index]['entity_type_id'] = $entityTypeModel->getEntityTypeId();
-            $row = $values[$index]; 
             
             if (!isset($row['attribute_set_id'])) {
                 $defaultAttributeSet = $entityTypeModel->getDefaultAttributeSetId();
@@ -257,6 +256,7 @@ abstract class EcomDev_PHPUnit_Model_Mysql4_Fixture_AbstractEav
                 
                 $values[$index]['attribute_set_id'] = $defaultAttributeSet;
             }
+            $row = $values[$index];
 
             // Preparing entity table record
             $entity = $this->_getTableRecord($row, $entityTableColumns);


### PR DESCRIPTION
This pull fixes an issue where the attribute_set_id would be assigned in the $values[$index][...], but not in the $row variable (which is pulled from $values[$index]).

I stumbled on this problem while running unittests from groupscatalog2 https://github.com/Vinai/groupscatalog2 (catalog_product entities in the global.yml file).
