### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Contributions
 
 If you want to take a part in improving our extension please create branches based on dev one. 
 
-###Create your contribution branch: 
+### Create your contribution branch: 
    
 	$ git checkout -b [your-name]/[feature] dev
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
