### PR TITLE
Reset _beforeForwardInfo to make multiple forward assertions possible

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Controller/Request/Http.php
+++ b/app/code/community/EcomDev/PHPUnit/Controller/Request/Http.php
@@ -175,6 +175,7 @@ class EcomDev_PHPUnit_Controller_Request_Http
         $this->_route = null;
         $this->_directFrontNames = null;
         $this->_controllerModule = null;
+        $this->_beforeForwardInfo = null;
         return $this;
     }
 


### PR DESCRIPTION
`assertRequestForwarded` and `assertRequestNotForwarded` only worked once because the internal property was not resetted.