### PR TITLE
Fix default value for 'attribute_set_id'.

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/Model/Fixture/Processor/Tables.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Fixture/Processor/Tables.php
@@ -107,7 +107,7 @@ class EcomDev_PHPUnit_Model_Fixture_Processor_Tables
             $this->getResource()->cleanTable($tableEntity);
         }
         foreach (array_keys($data) as $tableEntity) {
-            if (isset($restoreTableData[$tableEntity])) {
+            if ( ! empty($restoreTableData[$tableEntity])) {
                 $this->getResource()->loadTableData($tableEntity, $restoreTableData[$tableEntity]);
             }
         }

--- a/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture/AbstractEav.php
+++ b/app/code/community/EcomDev/PHPUnit/Model/Mysql4/Fixture/AbstractEav.php
@@ -255,7 +255,7 @@ abstract class EcomDev_PHPUnit_Model_Mysql4_Fixture_AbstractEav
                     $defaultAttributeSet = 0;
                 }
                 
-                $values[$index]['attribute_set_id'] = $defaultAttributeSet;
+                $row['attribute_set_id'] = $defaultAttributeSet;
             }
 
             // Preparing entity table record


### PR DESCRIPTION
The variable "$row" is passed to `_getTableRecord`, but since `$row` is a copy of `$value[$index]` it was not receiving the default attribute_set_id.