### PR TITLE
Fixed illegal offset warning

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/bootstrap.php
+++ b/app/code/community/EcomDev/PHPUnit/bootstrap.php
@@ -11,6 +11,10 @@ if (isset($_SERVER['MAGENTO_DIRECTORY'])) {
     $_baseDir = getcwd();
 }
 
+if(preg_match('/(.*)\.modman/', $_baseDir, $matches)) {
+    $_baseDir = $matches[1].'htdocs';
+}
+
 // Include Mage file by detecting app root
 require_once $_baseDir . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'Mage.php';
 

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,11 @@
 {
-    "name": "ecomdev/ecomdev_phpunit",
+    "name": "ambimax/ecomdev_phpunit",
     "license": "OSL-3.0",
     "type": "magento-module",
     "description": "Magento PHPUnit Integration",
     "homepage": "http://www.ecomdev.org/shop/code-testing/php-unit-test-suite.html",
     "require": {
-        "magento-hackathon/magento-composer-installer": "*",
-        "phpunit/phpunit": "5.7.*"
+        "magento-hackathon/magento-composer-installer": "*"
     },
     "replace": {
         "ivanchepurnyi/ecomdev_phpunit":"*"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "http://www.ecomdev.org/shop/code-testing/php-unit-test-suite.html",
     "require": {
         "magento-hackathon/magento-composer-installer": "*",
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "5.7.*"
     },
     "replace": {
         "ivanchepurnyi/ecomdev_phpunit":"*"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "http://www.ecomdev.org/shop/code-testing/php-unit-test-suite.html",
     "require": {
         "magento-hackathon/magento-composer-installer": "*",
-        "phpunit/phpunit": "4.1.*"
+        "phpunit/phpunit": "4.8.*"
     },
     "replace": {
         "ivanchepurnyi/ecomdev_phpunit":"*"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "magento-hackathon/magento-composer-installer": "*"
     },
     "replace": {
-        "ivanchepurnyi/ecomdev_phpunit":"*"
+        "ecomdev/ecomdev_phpunit":"*"
     },
     "authors":[
         {

--- a/lib/Spyc/spyc.php
+++ b/lib/Spyc/spyc.php
@@ -772,6 +772,7 @@ class Spyc {
 
       $_arr = array_merge ($_arr, $value);
     } else if ($key || $key === '' || $key === '0') {
+        if (!is_array ($_arr)) { $_arr = array (); }
       $_arr[$key] = $value;
     } else {
       if (!is_array ($_arr)) { $_arr = array ($value); $key = 0; }


### PR DESCRIPTION
Fixes this warning:

`PHP Fatal error:  Uncaught Exception: Warning: Illegal string offset 'default/catalog/inventory/enabled'  in ~/.modman/ecomdev_phpunit/lib/Spyc/spyc.php on line 775`